### PR TITLE
Semicolon should be optional in 'memberNameExtractor' regular expression.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-﻿var memberNameExtractor = new RegExp("return (.*);");
+﻿var memberNameExtractor = new RegExp("return (.*);?");
 
 export function getMemberNameFromSelector<TResult>(name: (x?: TResult) => any) {
     var m = memberNameExtractor.exec(name + "");


### PR DESCRIPTION
This change is required because semicolons are optional in both JavaScript and TypeScript at the end of statements. 

Statement-ending semicolons are sometimes removed by JS minifier, so valid code in development environment might fail in production.